### PR TITLE
Update packages to React 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ function MyComponent(props) {
 
 ```
 
-#### Transitions (see [CSSTransitionGroup](https://github.com/reactjs/react-transition-group) for details)
+#### Transitions (see [react-transition-group](https://github.com/reactjs/react-transition-group) for details)
 
 ```javascript
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,9 +12,13 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _CSSTransitionGroup = require('react-transition-group/CSSTransitionGroup');
+var _CSSTransition = require('react-transition-group/CSSTransition');
 
-var _CSSTransitionGroup2 = _interopRequireDefault(_CSSTransitionGroup);
+var _CSSTransition2 = _interopRequireDefault(_CSSTransition);
+
+var _TransitionGroup = require('react-transition-group/TransitionGroup');
+
+var _TransitionGroup2 = _interopRequireDefault(_TransitionGroup);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -117,17 +121,21 @@ var Route = exports.Route = function (_Component) {
 
 
         return _react2.default.createElement(
-            _CSSTransitionGroup2.default,
-            {
-                className: className,
-                transitionName: name,
-                transitionAppear: appear,
-                transitionAppearTimeout: appearTimeout,
-                transitionEnter: enter,
-                transitionEnterTimeout: enterTimeout,
-                transitionLeave: leave,
-                transitionLeaveTimeout: leaveTimeout },
-            childNodes
+            _TransitionGroup2.default,
+            null,
+            _react2.default.createElement(
+                _CSSTransition2.default,
+                {
+                    className: className,
+                    transitionName: name,
+                    transitionAppear: appear,
+                    transitionAppearTimeout: appearTimeout,
+                    transitionEnter: enter,
+                    transitionEnterTimeout: enterTimeout,
+                    transitionLeave: leave,
+                    transitionLeaveTimeout: leaveTimeout },
+                childNodes
+            )
         );
     };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import React, {Component, cloneElement} from 'react';
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import CSSTransition from "react-transition-group/CSSTransition";
+import TransitionGroup from 'react-transition-group/TransitionGroup';
 
 export const routes = [];
 
@@ -78,17 +79,19 @@ export class Route extends Component {
         } = transition;
 
         return (
-            <CSSTransitionGroup
-                className={className}
-                transitionName={name}
-                transitionAppear={appear}
-                transitionAppearTimeout={appearTimeout}
-                transitionEnter={enter}
-                transitionEnterTimeout={enterTimeout}
-                transitionLeave={leave}
-                transitionLeaveTimeout={leaveTimeout}>
+            <TransitionGroup>
+                <CSSTransition
+                    className={className}
+                    transitionName={name}
+                    transitionAppear={appear}
+                    transitionAppearTimeout={appearTimeout}
+                    transitionEnter={enter}
+                    transitionEnterTimeout={enterTimeout}
+                    transitionLeave={leave}
+                    transitionLeaveTimeout={leaveTimeout}>
                 {childNodes}
-            </CSSTransitionGroup>
+                </CSSTransition>
+            </TransitionGroup>
         );
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "url": "https://github.com/ianmcgregor/react-micro-router"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.0",
-    "babel-core": "^6.24.0",
-    "babel-eslint": "^7.1.1",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-eslint": "^8.2.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "chai": "^3.5.0",
-    "enzyme": "^2.7.1",
-    "eslint-plugin-react": "^6.10.0",
-    "jest": "^19.0.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "1.1.1",
+    "eslint-plugin-react": "^7.7.0",
+    "jest": "^22.1.4",
     "mocha": "^3.2.0",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "react": "^15.4.2",
-    "react-transition-group": "^1.1.3"
+    "react": "^16.2.0",
+    "react-transition-group": "^2.2.1"
   }
 }

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -6,6 +6,9 @@ const getCurrentPath = router.getCurrentPath;
 const getParams = router.getParams;
 // const jsdom = require('jsdom');
 const enzyme = require('enzyme');
+const adapter = require("enzyme-adapter-react-16");
+
+enzyme.configure({ adapter: new adapter() });
 
 // broken in jest env:
 // jsdom.changeURL(window, 'https://example.com/');


### PR DESCRIPTION
- Updates react/react-dom packages to ^16.2
- Removes `react-addons-test-utils`
- Updates other packages to more recent versions
- Updates `react-transition-group` to use current version & reflect changes in `Route`
- Update enzyme to use its new adapter mechanism [see here](https://github.com/airbnb/enzyme/tree/master/packages/enzyme-adapter-react-16)

I also updated the tests. The TransitionGroup changes seem to work, but I would certainly welcome another eye on that.

Thanks!
#devconunite