### PR TITLE
Ensuring anchor attributes can be assigned to Link component's anchor tag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,8 @@ export function Link({
     href,
     replace = false,
     activeClassName = "active",
-    match = null
+    match = null,
+    ...rest
 }) {
     const path = to || href;
 
@@ -126,7 +127,7 @@ export function Link({
     }
 
     return (
-        <a className={className} href={path} onClick={onClick}>
+        <a className={className} href={path} onClick={onClick} {...rest}>
             {children}
         </a>
     );


### PR DESCRIPTION
A two line change which deconstructs all remaining props passed to the `Link` component into a var called `rest`.

`rest` in turn, is then deconstructed into the `<a>` tag returned by the `Link component`

Why? So additional anchor tag attributes can be passed in! Such as `tabIndex`

See original issue [here](https://github.com/ianmcgregor/react-micro-router/issues/10)