### PR TITLE
Add FaaC support for better type integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,16 @@ function MyComponent(props) {
 
 ```
 
+#### TypeScript
+
 Use `ComponentRouteProps` to get access to `path` and `params` in your component when using TypeScript.
 
 ```tsx
 import {ComponentRouteProps} from 'react-micro-router';
 
-type Props = ComponentRouteProps & {
+type Props = {
     text: string;
+    route: ComponentRouteProps
 }
 
 function MyComponent(props: Props) {
@@ -121,6 +124,29 @@ function MyComponent(props: Props) {
             <p>{params[0]}</p>
             <p>{props.text}</p>
         </div>
+    );
+}
+```
+
+Note: when calling the component Typescript will complain about the props not being present. To avoid this, either 
+allow an undefined `route` prop:
+
+```ts
+type Props = {
+  text: string;
+  route?: ComponentRouteProps;
+}
+```
+
+Or use a function as a child to render child components:
+
+```tsx
+function Router(props) {
+  
+    return (
+        <Route>
+          {(route) => <ChildComponent route={route} otherProp={false} />}
+        </Route>
     );
 }
 ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,10 +2,8 @@ import React, { Component, AnchorHTMLAttributes } from "react";
 import { CSSTransitionProps } from "react-transition-group/CSSTransition";
 export declare const routes: Route[];
 export declare type ComponentRouteProps = {
-    route: {
-        path: string;
-        params: string[];
-    };
+    path: string;
+    params: string[];
 };
 export declare const location: {
     path: () => string;
@@ -16,7 +14,7 @@ declare type RouteProps = {
     exact?: boolean;
     transition?: CSSTransitionProps;
     className?: string;
-    children: any;
+    children: React.ReactNode | ((props: ComponentRouteProps) => JSX.Element);
 };
 export declare class Route extends Component<RouteProps> {
     constructor(props: RouteProps);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,8 +26,6 @@ var _CSSTransition = _interopRequireDefault(require("react-transition-group/CSST
 
 var _TransitionGroup = _interopRequireDefault(require("react-transition-group/TransitionGroup"));
 
-var _utils = require("./utils");
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
@@ -95,27 +93,39 @@ class Route extends _react.Component {
       className
     } = this.props;
     const active = isMatch(path, exact);
-    let childNodes = active ? _react.default.Children.toArray(children) : [];
+    let childNodes;
 
-    if (childNodes.length) {
-      const params = getParams(path);
-      childNodes = childNodes.map((child, i) => {
-        if (!(0, _utils.isReactElement)(child)) {
-          return child;
-        }
+    if (!active) {
+      childNodes = [];
+    } else if (typeof children === "function") {
+      const childProps = {
+        params: getParams(path),
+        path
+      };
+      childNodes = children(childProps);
+    } else {
+      childNodes = _react.default.Children.toArray(children);
 
-        if (typeof child.type === 'string' || child.type === Route) {
-          return child;
-        }
-
-        return /*#__PURE__*/(0, _react.cloneElement)(child, {
-          key: "child".concat(i),
-          route: {
-            params,
-            path
+      if (childNodes.length) {
+        const params = getParams(path);
+        childNodes = childNodes.map((child, i) => {
+          if (! /*#__PURE__*/(0, _react.isValidElement)(child)) {
+            return child;
           }
+
+          if (typeof child.type === 'string' || child.type === Route) {
+            return child;
+          }
+
+          return /*#__PURE__*/(0, _react.cloneElement)(child, {
+            key: "child".concat(i),
+            route: {
+              params,
+              path
+            }
+          });
         });
-      });
+      }
     }
 
     if (!transition) {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -80,6 +80,35 @@ describe("Route with params", () => {
     });
 });
 
+describe('route with function as a child', () => {
+    beforeAll(() => {
+        changeURL("/mocked/faac")
+
+        wrapper = enzyme.mount(
+          <div>
+              <Route path="/mocked/no">
+                  {() => <div>Hidden</div>}
+              </Route>
+              <Route path="/mocked/faac">
+                  {(route) => <div>{route.path}</div>}
+              </Route>
+          </div>
+        )
+    })
+
+    afterAll(() => {
+        wrapper.unmount();
+    });
+
+    it("should not display hidden div", () => {
+        expect(wrapper.contains(<div>Hidden</div>)).toBe(false);
+    });
+
+    it("should pass props via faac", () => {
+        expect(wrapper.contains(<div>/mocked/faac</div>)).toBe(true);
+    })
+});
+
 describe("Nested route", () => {
     beforeAll(() => {
         changeURL("/mocked/child");

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -80,6 +80,51 @@ describe("Route with params", () => {
     });
 });
 
+describe('child route prop', () => {
+    const ComponentA = (props) =>
+      <div>
+          <span>{props.route.path}</span>
+          <span>{props.route.params[0]}</span>
+      </div>
+
+    const ComponentB = (props) =>
+      <div>
+          {props.route.path} - B
+      </div>
+
+    beforeAll(() => {
+        changeURL(`/mocked?q="test"`);
+
+        wrapper = enzyme.mount(
+          <div>
+              <Route path="/mocked(.*)">
+                  <ComponentA />
+                  <ComponentB />
+              </Route>
+          </div>
+        )
+    })
+
+    afterAll(() => {
+        wrapper.unmount();
+    })
+
+    it("passes route props to child all components", () => {
+        expect(wrapper.contains(
+          <div>
+              <span>/mocked(.*)</span>
+              <span>?q="test"</span>
+          </div>)
+        ).toBe(true);
+
+        expect(wrapper.contains(
+          <div>
+              /mocked(.*) - B
+          </div>
+        ))
+    })
+});
+
 describe('route with function as a child', () => {
     beforeAll(() => {
         changeURL("/mocked/faac")

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,0 @@
-import React from "react";
-
-export const isReactElement = (element: any): element is React.ReactElement => {
-  return typeof element === 'object' && element !== null && element.$$typeof === Symbol.for('react.element');
-};


### PR DESCRIPTION
Following my previous PR - when using the types in a child component you often get warnings like this when using your `<Child />` component in a `<Route />`:

```TS2741: Property `route` is missing in type `{}` but required in type `ComponentRouteProps` ```

This can be avoided by using `route?: ComponentRouteProps` but comes with the caveat that the child component will assume they are not present until you perform some kind of type check.

This PR adds the ability to use a function as a child (FaaC) to render the `<Route />` children - giving better type support as the prop can be passed directly to the children:

```tsx
<Route path="/">
  {(route) => (
    <>
      <Container />
      <Test route={route} />
    </>
  )}
</Route>
```

Note: this is completely optional and still works with regular child nodes.

Also removes custom util `isReactElement` in favour of React's build in `isValidElement`.